### PR TITLE
fix(renovate): group debian package and docker digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,13 @@
   "extends": [
     "config:recommended"
   ],
+  "packageRules": [
+    {
+      "matchDatasources": ["deb", "docker"],
+      "groupName": "debian packages",
+      "groupSlug": "debian-packages"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Problem

Renovate opens separate PRs for each Debian package version bump and the base image digest. When a package version is superseded upstream (e.g. `locales=2.41-12` → `2.41-12+deb13u2`), any open PR that doesn't include that bump fails to build because the old version is no longer available in the Debian mirrors.

## Fix

Group all `deb` and `docker` datasource updates into a single Renovate PR via `packageRules`. This ensures the base image digest and all pinned package versions always move together, keeping the Dockerfile internally consistent and CI green.