### PR TITLE
feat(renovate): add wine, wine-mono, and proton-ge version tracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,9 @@ FROM trixie-root AS build_stage_wine
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG WINE_BRANCH=devel
+# renovate: datasource=deb depName=winehq-devel registryUrl=https://dl.winehq.org/wine-builds/debian?suite=trixie&components=main
 ARG WINE_VERSION=10.10~trixie-1
+# renovate: datasource=github-releases depName=wine-mono/wine-mono extractVersion=^wine-mono-(?<version>.+)$
 ARG WINE_MONO_VERSION=10.1.0
 
 # renovate: suite=trixie depName=gnupg
@@ -113,6 +115,7 @@ USER ${USER}
 FROM trixie-root AS build_stage_proton
 
 ARG DEBIAN_FRONTEND="noninteractive"
+# renovate: datasource=github-releases depName=GloriousEggroll/proton-ge-custom extractVersion=^GE-Proton(?<version>.+)$
 ARG PROTON_GE_VERSION=10-15
 
 # renovate: suite=trixie depName=libvulkan1

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,16 @@
       "matchDatasources": ["deb", "docker"],
       "groupName": "debian packages",
       "groupSlug": "debian-packages"
+    },
+    {
+      "matchDepNames": ["wine-mono/wine-mono"],
+      "groupName": "wine mono",
+      "groupSlug": "wine-mono"
+    },
+    {
+      "matchDepNames": ["GloriousEggroll/proton-ge-custom"],
+      "groupName": "proton ge",
+      "groupSlug": "proton-ge"
     }
   ],
   "customManagers": [
@@ -19,6 +29,32 @@
       ],
       "registryUrlTemplate": "https://deb.debian.org/debian?suite={{#if suite }}{{suite}}{{else}}stable{{/if}}&components=main,contrib,non-free&binaryArch=amd64",
       "datasourceTemplate": "deb"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=deb\\s+depName=(?<depName>.*?)\\s+registryUrl=(?<registryUrl>.*?)\\nARG WINE_VERSION=(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "deb"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>.*?)\\s+extractVersion=(?<extractVersion>.*?)\\nARG WINE_MONO_VERSION=(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^wine-mono-(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>.*?)\\s+extractVersion=(?<extractVersion>.*?)\\nARG PROTON_GE_VERSION=(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^GE-Proton(?<version>.+)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add Renovate custom manager for `WINE_VERSION` ARG tracking `winehq-devel` from the WineHQ Debian repository
- Add Renovate custom manager for `WINE_MONO_VERSION` ARG tracking releases from `wine-mono/wine-mono` on GitHub (strips `wine-mono-` tag prefix)
- Add Renovate custom manager for `PROTON_GE_VERSION` ARG tracking releases from `GloriousEggroll/proton-ge-custom` on GitHub (strips `GE-Proton` tag prefix)
- Add `packageRules` grouping entries for Wine Mono and Proton GE to produce clean, named Renovate PRs