### PR TITLE
fix(ci): use wine tag instead of apt version string for branch name

### DIFF
--- a/.github/workflows/update-wine.yml
+++ b/.github/workflows/update-wine.yml
@@ -79,7 +79,7 @@ jobs:
         if: steps.versions.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          branch: chore/update-wine-${{ steps.versions.outputs.wine_version }}
+          branch: chore/update-wine-${{ steps.versions.outputs.wine_tag }}
           commit-message: "chore(deps): update wine to ${{ steps.versions.outputs.wine_version }} and wine-mono to ${{ steps.versions.outputs.mono_version }}"
           title: "chore(deps): update wine to ${{ steps.versions.outputs.wine_version }} and wine-mono to ${{ steps.versions.outputs.mono_version }}"
           body: |


### PR DESCRIPTION
The apt version string (`11.6~trixie-1`) contains a `~` which is not a valid git ref character, causing:

```
fatal: 'chore/update-wine-11.6~trixie-1' is not a valid branch name
```

Fix: use `wine_tag` (e.g. `wine-11.6`) for the branch name instead of `wine_version` (e.g. `11.6~trixie-1`). `wine_tag` was already being output by the versions step for the PR body link.