### PR TITLE
fix(renovate): remove spurious extractVersion capture from proton-ge regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ USER ${USER}
 FROM trixie-root AS build_stage_proton
 
 ARG DEBIAN_FRONTEND="noninteractive"
-# renovate: datasource=github-releases depName=GloriousEggroll/proton-ge-custom extractVersion=^GE-Proton(?<version>.+)$
+# renovate: datasource=github-releases depName=GloriousEggroll/proton-ge-custom
 ARG PROTON_GE_VERSION=10-15
 
 # renovate: suite=trixie depName=libvulkan1

--- a/renovate.json
+++ b/renovate.json
@@ -33,10 +33,11 @@
       "customType": "regex",
       "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>.*?)\\s+extractVersion=(?<extractVersion>.*?)\\nARG PROTON_GE_VERSION=(?<currentValue>.*)"
+        "#\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>.*?)\\nARG PROTON_GE_VERSION=(?<currentValue>.*)"
       ],
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^GE-Proton(?<version>.+)$"
+      "extractVersionTemplate": "^GE-Proton(?<version>.+)$",
+      "versioningTemplate": "loose"
     }
   ]
 }


### PR DESCRIPTION
Tested locally with `renovate --dry-run=full`. Two issues found and fixed.

## 1. Spurious `extractVersion` capture in `depName`

The `(?<depName>.*?)` capture in `matchStrings` was non-greedy but the trailing `\\s+extractVersion=(?<extractVersion>.*?)` pattern wasn't matching (Renovate doesn't support `extractVersion` as a named capture group). This caused the entire remainder of the comment line — `GloriousEggroll/proton-ge-custom extractVersion=^GE-Proton(?<version>.+)$` — to be slurped into `depName`, making the GitHub API lookup fail with `no-result`.

Fix: remove `extractVersion=...` from the comment and the `matchStrings` regex entirely.

## 2. Wrong versioning scheme (`semver-coerced` → `loose`)

After stripping the `GE-Proton` prefix, versions are `10-34`, `10-15` etc. — `MAJOR-MINOR` with a hyphen. `semver-coerced` (the default) can't parse these, so Renovate found no updates. Adding `"versioningTemplate": "loose"` handles arbitrary version strings and correctly orders `10-34` > `10-15`.

Both confirmed via dry run: dep is detected as `depName: "GloriousEggroll/proton-ge-custom"`, `versioning: "loose"`, `currentValue: "10-15"`, and the `10-34` release is available as an update.