### PR TITLE
chore(deps): update wine to 11.8~trixie-1 and wine-mono to 11.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,9 @@ FROM trixie-root AS build_stage_wine
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG WINE_BRANCH=devel
 # managed by .github/workflows/update-wine.yml — do not add a renovate comment here
-ARG WINE_VERSION=11.7~trixie-1
+ARG WINE_VERSION=11.8~trixie-1
 # version is derived from the Wine release tag; kept in sync by update-wine.yml
-ARG WINE_MONO_VERSION=11.0.0
+ARG WINE_MONO_VERSION=11.1.0
 
 # renovate: suite=trixie depName=gnupg
 ENV GNUPG_VERSION="2.4.7-21+deb13u1"


### PR DESCRIPTION
Automated update of the paired Wine + Wine Mono versions.

| Package | Current | New |
|---------|---------|-----|
| Wine (`winehq-devel`) | `11.7~trixie-1` | `11.8~trixie-1` |
| Wine Mono | `11.0.0` | `11.1.0` |

The Wine Mono version is derived directly from [`dlls/mscoree/mscoree_private.h`](https://gitlab.winehq.org/wine/wine/-/blob/wine-11.8/dlls/mscoree/mscoree_private.h) in the corresponding Wine release tag, ensuring the two are always in sync.